### PR TITLE
Update README.md

### DIFF
--- a/guide/02-prerequisites/README.md
+++ b/guide/02-prerequisites/README.md
@@ -129,6 +129,7 @@ FRAMES_STORAGE_CONN=$(az storage account show-connection-string \
 echo $FRAMES_STORAGE_CONN
 
 # Creating a blob container for our Camera Frames (name must be all small letters)
+#In case of keep getting Authentication Failure, Most probably its due to Date/Time not in sync between WSL2 and Host, try "sudo hwclock -s"
 FRAMES_STORAGE_CONTAINER="camframefiles"
 az storage container create \
     --account-name $FRAMES_STORAGE \


### PR DESCRIPTION
Whenever you put your laptop to sleep this will cause WSL2 date and time to be wrong, that will cause all Azure CLI operation to fail from bash. with Authentication Failure.

a workaround is to run "sudo hwclock -s"